### PR TITLE
Add "No event" to EventType enum

### DIFF
--- a/interfaces/xbos_demand_response.yaml
+++ b/interfaces/xbos_demand_response.yaml
@@ -27,12 +27,14 @@ Demand Response:
             units: event_type
             enum:
                 - value: 0
-                  description: Normal
+                  description: No event
                 - value: 1
-                  description: Moderate
+                  description: Normal
                 - value: 2
-                  description: High
+                  description: Moderate
                 - value: 3
+                  description: High
+                - value: 4
                   description: Special
         dr_status:
             type: integer


### PR DESCRIPTION
If DR status is inactive, we need a way to indicate that there is no type of the DR event. The 0-value is a logical place to put this.