### PR TITLE
Feature protobuf

### DIFF
--- a/interfaces/proto/hamilton.proto
+++ b/interfaces/proto/hamilton.proto
@@ -35,3 +35,50 @@ message Hamilton3C {
   uint32 buttons = 15;
   double occupancy = 16;
 }
+
+//Data specific to a Hamilton 330/370 sensor
+//Maintainer: Michael Andersen
+message Hamilton330 {
+  uint64 uptime = 1;
+  uint32 flags = 2;
+  double acc_x = 3;
+  double acc_y = 4;
+  double acc_z = 5;
+  double mag_x = 6;
+  double mag_y = 7;
+  double mag_z = 8;
+  double tmp_die = 9;
+  double tmp_voltage = 10;
+  double air_temp = 11;
+  double air_hum = 12;
+  double air_rh = 13;
+  double light_lux = 14;
+  uint32 buttons = 15;
+  double occupancy = 16;
+}
+
+//Published by Hamilton Border routers periodically
+message HamiltonBRLinkStats {
+  uint64 BadFrames = 1;
+  uint64 LostFrames = 2;
+  uint64 DropNotConnected = 3;
+  uint64 SumSerialReceived = 4;
+  uint64 SumDomainForwarded = 5;
+  uint64 SumDropNotConnected = 6;
+  uint64 SumDomainReceived = 7;
+  uint64 SumSerialForwarded = 8;
+  uint64 PublishOkay = 9;
+  uint64 PublishError = 10;
+}
+
+//Published by Hamilton Border routers for each message
+message HamiltonBRMessage {
+  string SrcMAC = 1;
+  string SrcIP = 2;
+  string PopID = 3;
+  int64 PopTime = 4;
+  int64 BRTime = 5;
+  int32 RSSI = 6;
+  int32 LQI = 7;
+  bytes Payload = 8;
+}

--- a/interfaces/proto/hamilton.proto
+++ b/interfaces/proto/hamilton.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+//This is designed to be included by the main xbos proto file and includes the
+//definitions for the Hamilton project
+//
+//Version 1.0
+package xbospb;
+
+//Data emitted from Hamilton Sensors
+//Maintainer: Michael Andersen
+message HamiltonData {
+  uint32 serial = 1;
+  string model = 2;
+  uint64 time = 3;
+  Hamilton3C h3c = 4;
+}
+
+//Data specific to a Hamilton 3C/7C sensor
+//Maintainer: Michael Andersen
+message Hamilton3C {
+  uint64 uptime = 1;
+  uint32 flags = 2;
+  double acc_x = 3;
+  double acc_y = 4;
+  double acc_z = 5;
+  double mag_x = 6;
+  double mag_y = 7;
+  double mag_z = 8;
+  double tmp_die = 9;
+  double tmp_voltage = 10;
+  double air_temp = 11;
+  double air_hum = 12;
+  double air_rh = 13;
+  double light_lux = 14;
+  uint32 buttons = 15;
+  double occupancy = 16;
+}

--- a/interfaces/proto/xbos.proto
+++ b/interfaces/proto/xbos.proto
@@ -10,3 +10,15 @@ package xbospb;
 
 // Hamilton Project definitions
 import "hamilton.proto";
+
+
+
+// Root union type
+// We reserve 50 fields per imported file
+message XBOS {
+
+  //Hamilton Fields
+  HamiltonData HamiltonData = 50;
+  HamiltonBRLinkStats HamiltonBRLinkStats = 51;
+  HamiltonBRMessage HamiltonBRMessage = 52;
+}

--- a/interfaces/proto/xbos.proto
+++ b/interfaces/proto/xbos.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+// This defines the protocol buffers used by XBOS with WaveMQ. The schema for
+// a wavemq xbos proto message is:
+//   xbosproto/RootMessageType
+//
+// Version 1.0
+package xbospb;
+
+
+// Hamilton Project definitions
+import "hamilton.proto";


### PR DESCRIPTION
This adds some protocol buffers that start off the process of defining the message types for XBOS on WAVEMQ.

