### PR TITLE
Thermostat Schedules YAML Files

### DIFF
--- a/interfaces/xbos_thermostat_schedule.yaml
+++ b/interfaces/xbos_thermostat_schedule.yaml
@@ -1,0 +1,12 @@
+Thermostat Schedule:
+    ponum: 2.1.2.2
+    description: Standard XBOS thermostat schedule interface
+    interface: i.xbos.thermostat_schedule
+    signals:
+        info:
+            - day_schedules
+    properties:
+        day_schedules:
+            type: map
+            description: Dictionary mapping a day of week to its specific schedule
+            required: true

--- a/interfaces/xbos_thermostat_schedule_block.yaml
+++ b/interfaces/xbos_thermostat_schedule_block.yaml
@@ -1,0 +1,31 @@
+Thermostat Schedule Block:
+    ponum: 2.1.2.2
+    description: Standard XBOS thermostat block schedule interface
+    interface: i.xbos.thermostat_schedule
+    signals:
+        info:
+            - cool_setting
+            - heat_setting
+            - system
+            - time
+    properties:
+        cool_setting:
+            type: float
+            description: Current Temperature Threshold for Cooling
+            required: true
+            units: degrees Fahrenheit
+        heat_setting:
+            type: float
+            description: Current Temperature Threshold for Heating
+            required: true
+            units: degrees Fahrenheit
+        system:
+            type: string
+            description: Setting state of thermostat
+            required: true
+            units: cool/heat/auto/off
+        time:
+            type: string
+            description:
+            required: true
+            units: rrule

--- a/interfaces/xbos_thermostat_schedule_day.yaml
+++ b/interfaces/xbos_thermostat_schedule_day.yaml
@@ -1,0 +1,12 @@
+Thermostat Schedule Day:
+    ponum: 2.1.2.2
+    description: Standard XBOS thermostat day schedule interface
+    interface: i.xbos.thermostat_schedule
+    signals:
+        info:
+            - blocks
+    properties:
+        blocks:
+            type: array
+            description: Array of Thermostat Block Schedules
+            required: true


### PR DESCRIPTION
@gtfierro This is the first draft of the YAML files for the thermostat schedule formats. The structs I'm trying to configure are the ThermostatSchedule, ThermostatDaySchedule, and ThermostatBlockSchedule structs within the thermSchedule.go file for the Pelican driver.

I couldn't find examples for some of the types and structs I was trying to add configuration for, and I wanted to point them out here:

- I could only find integer and boolean types. The structs I've defined include strings, maps, and arrays. How should I represent these in the YAML file, especially with the "units" field?
- I have three different structs, two of which are nested in one another.
Schedule = map between strings and day schedules
Day Schedule = array of block schedules
How should I represent this in YAML? Should I be using different ponum values for each struct?

I'm sure there's a couple more errors, but I thought it'd be most productive to just show what I did and correct the errors one by one.